### PR TITLE
Ignore `matchdelete()` error

### DIFF
--- a/autoload/highlightedput/highlight.vim
+++ b/autoload/highlightedput/highlight.vim
@@ -117,7 +117,7 @@ endfunction
 
 function s:matchdelete_all(matchIDs, ...) abort
   let winid = get(a:000, 0, win_getid())
-  return map(copy(a:matchIDs), { _, matchID -> matchdelete(matchID, winid) })
+  return map(copy(a:matchIDs), { _, matchID -> execute(printf('call matchdelete(%d, %d)', matchID, winid), 'silent!') })
 endfunction
 
 


### PR DESCRIPTION
Call `matchdelete()` with `silent!` to ignore errors.

If highlights are deleted by others, this plugin's `matchdelete()` fails.
Then, it repeatedly tries and fails to `matchdelete()` the highlights, since `self.matchIDs` are not cleared due to the error abort.
